### PR TITLE
refactor: streamline check-in class names

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/src/Requests/Appointments/AppointmentCheckIn/AppointmentCancelCheckin.php
+++ b/src/Requests/Appointments/AppointmentCheckIn/AppointmentCancelCheckin.php
@@ -6,17 +6,17 @@ use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
 /**
- * CreateAppointmentCheckin
+ * CreateAppointmentCancelCheckin
  *
- * Check in this appointment.
+ * Cancel appointment check-in process. It cannot be called if the check-in process has been completed.
  */
-class CreateAppointmentCheckin extends Request
+class AppointmentCancelCheckin extends Request
 {
     protected Method $method = Method::POST;
 
     public function resolveEndpoint(): string
     {
-        return "/appointments/{$this->appointmentid}/checkin";
+        return "/appointments/{$this->appointmentid}/cancelcheckin";
     }
 
     /**

--- a/src/Requests/Appointments/AppointmentCheckIn/AppointmentCompleteCheckin.php
+++ b/src/Requests/Appointments/AppointmentCheckIn/AppointmentCompleteCheckin.php
@@ -6,17 +6,17 @@ use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
 /**
- * CreateAppointmentCancelCheckin
+ * CreateAppointmentCheckin
  *
- * Cancel appointment check-in process. It cannot be called if the check-in process has been completed.
+ * Check in this appointment.
  */
-class CreateAppointmentCancelCheckin extends Request
+class AppointmentCompleteCheckin extends Request
 {
     protected Method $method = Method::POST;
 
     public function resolveEndpoint(): string
     {
-        return "/appointments/{$this->appointmentid}/cancelcheckin";
+        return "/appointments/{$this->appointmentid}/checkin";
     }
 
     /**

--- a/src/Requests/Appointments/AppointmentCheckIn/AppointmentStartCheckin.php
+++ b/src/Requests/Appointments/AppointmentCheckIn/AppointmentStartCheckin.php
@@ -10,7 +10,7 @@ use Saloon\Http\Request;
  *
  * Notifies that the appointment check-in process has started
  */
-class CreateAppointmentStartCheckin extends Request
+class AppointmentStartCheckin extends Request
 {
     protected Method $method = Method::POST;
 

--- a/src/Requests/Encounter/ReviewSystems/UpdateEncounterReviewOfSystems.php
+++ b/src/Requests/Encounter/ReviewSystems/UpdateEncounterReviewOfSystems.php
@@ -27,16 +27,10 @@ class UpdateEncounterReviewOfSystems extends Request implements HasBody
      * @param  int  $encounterid encounterid
      * @param  null|bool  $hpitoros Whether ROS is as noted in HPI.
      * @param  null|bool  $replacesectionnote If true, will replace the existing section note with the new one. If false, will append to the existing note.
-     * @param  null|string  $reportedby
-     *                     The type of person who reported information for the review of systems template. One of Patient, Parent, Caregiver, or Staff.
-     *                  This will always be set to null if you do not pass any templateids even if you set this to a non null value in the API. This is because this field is only valid when there is an ROS template added to the encounter.
      * @param  null|array  $reviewofsystems This is a JSON structure containing everything you want the ROS to now contain.  If you call the GET version of this call you can see some sample output.  It is extremely important to note that anything you pass in will become the new ROS. Even if you only wish to make an addition, you will need to pass in the whole output of the GET plus your addition, otherwise anything you don't pass in will be removed.
      * @param  null|string  $sectionnote The text to be updated to the review of systems section note for this encounter.
      * @param  null|array  $templateids This is a JSON array of the template ids that should remain on (or be added to) the ROS. Any template ids not included in this list will be removed from the ROS.
      * @param  null|bool  $wellchildreplacesectionnote If true, will replace the existing well child section note with the new one. If false, will append to the existing note.
-     * @param  null|string  $wellchildreportedby
-     *                     The type of person who reported information for the well child review of systems template. One of Patient, Parent, Caregiver, or Staff.
-     *                  This will always be set to null if you do not pass any wellchildtemplateids even if you set this to a non null value in the API. This is because this field is only valid when there is a Well Child ROS template added to the encounter.
      * @param  null|array  $wellchildros This is a JSON structure containing everything you want the well child ROS to now contain.  If you call the GET version of this call you can see some sample output.  It is extremely important to note that anything you pass in will become the new well child ROS. Even if you only wish to make an addition, you will need to pass in the whole output of the GET plus your addition, otherwise anything you don't pass in will be removed.
      * @param  null|string  $wellchildsectionnote The text to be updated to the well child review of systems section note for this encounter.
      * @param  null|array  $wellchildtemplateids This is a JSON array of the well child template ids that should remain on (or be added to) the ROS. Any template ids not included in this list will be removed from the well child ROS section.

--- a/src/Requests/PracticeConfiguration/RequiredFieldsCheck/ListDepartmentCheckinRequiredFields.php
+++ b/src/Requests/PracticeConfiguration/RequiredFieldsCheck/ListDepartmentCheckinRequiredFields.php
@@ -4,6 +4,7 @@ namespace ChrisReedIO\AthenaSDK\Requests\PracticeConfiguration\RequiredFieldsChe
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Http\Response;
 
 /**
  * ListDepartmentCheckinRequiredFields
@@ -25,5 +26,10 @@ class ListDepartmentCheckinRequiredFields extends Request
     public function __construct(
         protected int $departmentid,
     ) {
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return $response->json('fieldlist');
     }
 }

--- a/src/Resources/Appointments/CheckInResource.php
+++ b/src/Resources/Appointments/CheckInResource.php
@@ -2,15 +2,21 @@
 
 namespace ChrisReedIO\AthenaSDK\Resources\Appointments;
 
-use ChrisReedIO\AthenaSDK\Requests\Appointments\AppointmentCheckIn\CreateAppointmentCancelCheckin;
-use ChrisReedIO\AthenaSDK\Requests\Appointments\AppointmentCheckIn\CreateAppointmentCheckin;
-use ChrisReedIO\AthenaSDK\Requests\Appointments\AppointmentCheckIn\CreateAppointmentStartCheckin;
+use ChrisReedIO\AthenaSDK\Requests\Appointments\AppointmentCheckIn\AppointmentCancelCheckin;
+use ChrisReedIO\AthenaSDK\Requests\Appointments\AppointmentCheckIn\AppointmentCompleteCheckin;
+use ChrisReedIO\AthenaSDK\Requests\Appointments\AppointmentCheckIn\AppointmentStartCheckin;
 use ChrisReedIO\AthenaSDK\Requests\Appointments\AppointmentCheckIn\GetAppointmentCheckinRequirements;
+use ChrisReedIO\AthenaSDK\Requests\PracticeConfiguration\RequiredFieldsCheck\ListDepartmentCheckinRequiredFields;
 use ChrisReedIO\AthenaSDK\Resource;
 use Saloon\Http\Response;
 
 class CheckInResource extends Resource
 {
+    public function fields(string $departmentId): array
+    {
+        return $this->connector->send(new ListDepartmentCheckinRequiredFields($departmentId))->dtoOrFail();
+    }
+
     public function validate(string $appointmentId): Response
     {
         return $this->connector->send(new GetAppointmentCheckinRequirements($appointmentId));
@@ -18,16 +24,16 @@ class CheckInResource extends Resource
 
     public function start(string $appointmentId): Response
     {
-        return $this->connector->send(new CreateAppointmentStartCheckin($appointmentId));
+        return $this->connector->send(new AppointmentStartCheckin($appointmentId));
     }
 
     public function complete(string $appointmentId): Response
     {
-        return $this->connector->send(new CreateAppointmentCheckin($appointmentId));
+        return $this->connector->send(new AppointmentCompleteCheckin($appointmentId));
     }
 
     public function cancel(string $appointmentId): Response
     {
-        return $this->connector->send(new CreateAppointmentCancelCheckin($appointmentId));
+        return $this->connector->send(new AppointmentCancelCheckin($appointmentId));
     }
 }


### PR DESCRIPTION
- Rename check-in request classes for clarity and consistency
- Introduce a method to retrieve required fields for check-in based on department ID
- Ensure that all check-in related actions are referenced with consistent and clear class names

This change simplifies the codebase by making class names more intuitive, which could potentially reduce the likelihood of future bugs and improve developer experience when working with the check-in process.