### PR TITLE
feat: add showAll param to Departments list

### DIFF
--- a/src/Resources/Departments.php
+++ b/src/Resources/Departments.php
@@ -12,8 +12,8 @@ class Departments extends Resource
     /**
      * @return LazyCollection<DepartmentData>
      */
-    public function list(): LazyCollection
+    public function list(bool $showAll = false): LazyCollection
     {
-        return $this->connector->paginate(new ListDepartments())->collect();
+        return $this->connector->paginate(new ListDepartments(showalldepartments: $showAll))->collect();
     }
 }


### PR DESCRIPTION
Setting this to true, includes departments that are hidden in the AthenaOne patient portal.