### PR TITLE
feat: filter patientLocations by departmentId

### DIFF
--- a/src/Resources/Departments.php
+++ b/src/Resources/Departments.php
@@ -18,8 +18,8 @@ class Departments extends Resource
         return $this->connector->paginate(new ListDepartments(showalldepartments: $showAll))->collect();
     }
 
-    public function patientLocations(): LazyCollection
+    public function patientLocations(string|int $departmentId): LazyCollection
     {
-        return $this->connector->paginate(new ListPatientLocations())->collect();
+        return $this->connector->paginate(new ListPatientLocations(intval($departmentId)))->collect();
     }
 }


### PR DESCRIPTION
- Update the `patientLocations` method to accept a `$departmentId` parameter.
- Ensure the `ListPatientLocations` query uses the provided department ID for filtering results.
- This change allows users to retrieve location data specific to a department, enhancing the API's usability.