### PR TITLE
feat: enable showPatientDetail in AppointmentSubscriptions

### DIFF
--- a/src/Data/Practice/PatientLocationData.php
+++ b/src/Data/Practice/PatientLocationData.php
@@ -10,8 +10,8 @@ readonly class PatientLocationData extends AthenaData
         public ?int $athenaId = null,
         public ?string $name = null,
         public ?bool $isDefault = null,
-    )
-    { }
+    ) {
+    }
 
     public static function fromArray(array $data): static
     {

--- a/src/Resources/Appointments/AppointmentSubscriptions.php
+++ b/src/Resources/Appointments/AppointmentSubscriptions.php
@@ -39,7 +39,7 @@ class AppointmentSubscriptions extends Resource
             leaveUnprocessed: $leaveUnprocessed,
             showCopay: true,
             showInsurance: true,
-            // showPatientDetail: true,
+            showPatientDetail: true,
         );
 
         return $this->connector


### PR DESCRIPTION
Uncommented the `showPatientDetail` flag to display patient details in appointment subscriptions, enhancing the detail level provided during the appointment setup process.