### PR TITLE
feat: add dto handling for appointment details

### DIFF
--- a/src/Requests/Appointments/Appointment/GetAppointmentDetails.php
+++ b/src/Requests/Appointments/Appointment/GetAppointmentDetails.php
@@ -2,8 +2,10 @@
 
 namespace ChrisReedIO\AthenaSDK\Requests\Appointments\Appointment;
 
+use ChrisReedIO\AthenaSDK\Data\Appointment\AppointmentData;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Http\Response;
 
 /**
  * GetAppointmentDetails
@@ -59,5 +61,11 @@ class GetAppointmentDetails extends Request
             'showpatientdetail' => $this->showpatientdetail,
             'showtelehealth' => $this->showtelehealth,
         ]);
+    }
+
+    public function createDtoFromResponse(Response $response): AppointmentData
+    {
+        // dd($response->json());
+        return AppointmentData::fromArray($response->json()[0]);
     }
 }

--- a/src/Resources/Appointments.php
+++ b/src/Resources/Appointments.php
@@ -2,6 +2,8 @@
 
 namespace ChrisReedIO\AthenaSDK\Resources;
 
+use ChrisReedIO\AthenaSDK\Data\Appointment\AppointmentData;
+use ChrisReedIO\AthenaSDK\Requests\Appointments\Appointment\GetAppointmentDetails;
 use ChrisReedIO\AthenaSDK\Resource;
 use ChrisReedIO\AthenaSDK\Resources\Appointments\AppointmentStatus;
 use ChrisReedIO\AthenaSDK\Resources\Appointments\AppointmentSubscriptions;
@@ -34,5 +36,15 @@ class Appointments extends Resource
     public function checkin(): CheckInResource
     {
         return new CheckInResource($this->connector);
+    }
+
+    public function get(
+        int $appointmentId,
+        ?bool $includeClaim = null,
+        ?bool $includeCopay = null,
+        ?bool $includeInsurance = null,
+        ?bool $includePatient = null,
+    ): AppointmentData {
+        return $this->connector->send(new GetAppointmentDetails($appointmentId))->dtoOrFail();
     }
 }


### PR DESCRIPTION
- Introduce `AppointmentData` DTO for response parsing
- Add `createDtoFromResponse` method to handle conversion
- Extend `Appointments` resource with `get` method for retrieval
- Enable direct fetching of appointment details using the new DTO

This change simplifies the process of fetching and handling appointment details by introducing a Data Transfer Object (DTO), which ensures type safety and encapsulates the data conversion logic.