### PR TITLE
🐛 fix(athena-connector): adjusted token expiration by subtracting a minute

### DIFF
--- a/src/AthenaConnector.php
+++ b/src/AthenaConnector.php
@@ -52,7 +52,9 @@ class AthenaConnector extends Connector implements HasPagination
             $authenticator = Cache::get('athena_access_token');
             if (! $authenticator) {
                 $authenticator = $this->getAccessToken();
-                $ttl = now()->diff($authenticator->getExpiresAt());
+                $expiresAt = $authenticator->getExpiresAt();
+                $expiresAt = $expiresAt->sub(new \DateInterval('PT1M'));
+                $ttl = now()->diff($expiresAt);
                 Cache::put('athena_access_token', $authenticator, $ttl);
             }
             $this->authenticate($authenticator);


### PR DESCRIPTION
This ensures the token is refreshed before actual expiration to avoid authentication errors.