### PR TITLE
🐛 fix(data): corrected `createsEncounter` mapping in `AppointmentTypeData`

### DIFF
--- a/src/Data/Appointment/AppointmentTypeData.php
+++ b/src/Data/Appointment/AppointmentTypeData.php
@@ -30,7 +30,7 @@ readonly class AppointmentTypeData extends AthenaData
             patient: self::toBool($data['patient']),
             generic: self::toBool($data['generic']),
             templateOnly: self::toBool($data['templatetypeonly']),
-            createsEncounter: self::toBool(['createencounteroncheckin'])
+            createsEncounter: self::toBool($data['createencounteroncheckin'])
         );
     }
 }

--- a/src/Data/Patient/PatientData.php
+++ b/src/Data/Patient/PatientData.php
@@ -9,7 +9,7 @@ use DateTime;
 readonly class PatientData extends AthenaData
 {
     /**
-     * @param  string|null  $sex - M/F
+     * @param  string|null  $sex  - M/F
      */
     public function __construct(
         public ?int $athenaId = null,


### PR DESCRIPTION
Corrected the data key reference for `createsEncounter` to ensure accurate data mapping.