### PR TITLE
Add isExpired property to ReferralAuthorizationData and update related tests

### DIFF
--- a/src/Data/Patient/ReferralAuthorizationData.php
+++ b/src/Data/Patient/ReferralAuthorizationData.php
@@ -14,6 +14,7 @@ readonly class ReferralAuthorizationData extends AthenaData
         public array $appointmentIds = [],
         public ?DateTime $startDate = null,
         public ?DateTime $expirationDate = null,
+        public bool $isExpired = false,
         public ?string $referralAuthNumber = null,
         public ?bool $noReferralRequired = null,
         public ?bool $specifiesVisits = null,
@@ -38,7 +39,8 @@ readonly class ReferralAuthorizationData extends AthenaData
                 array_filter($data['appointmentids'] ?? [], static fn (mixed $id): bool => $id !== null && $id !== '')
             )),
             startDate: isset($data['startdate']) ? new DateTime($data['startdate']) : null,
-            expirationDate: isset($data['expirationdate']) ? new DateTime($data['expirationdate']) : null,
+            expirationDate: isset($data['enddate']) ? new DateTime($data['enddate']) : null,
+            isExpired: self::toBool($data['expired'] ?? null),
             referralAuthNumber: $data['referralauthnumber'] ?? null,
             noReferralRequired: self::toBool($data['noreferralrequired'] ?? null),
             specifiesVisits: self::toBool($data['specifiesvisits'] ?? ($data['visits'] ?? null)),

--- a/tests/Unit/Data/ReferralAuthorizationDataTest.php
+++ b/tests/Unit/Data/ReferralAuthorizationDataTest.php
@@ -9,7 +9,8 @@ it('maps representative referral authorization payload fields into a dto', funct
         'insuranceid' => '12345',
         'appointmentids' => ['9001', '9002'],
         'startdate' => '2026-03-01',
-        'expirationdate' => '2026-03-31',
+        'enddate' => '2026-03-31',
+        'expired' => 'false',
         'referralauthnumber' => 'AUTH-123',
         'noreferralrequired' => 'false',
         'specifiesvisits' => 'true',
@@ -28,6 +29,7 @@ it('maps representative referral authorization payload fields into a dto', funct
         ->and($authorization->appointmentIds)->toBe([9001, 9002])
         ->and($authorization->startDate?->format('Y-m-d'))->toBe('2026-03-01')
         ->and($authorization->expirationDate?->format('Y-m-d'))->toBe('2026-03-31')
+        ->and($authorization->isExpired)->toBeFalse()
         ->and($authorization->referralAuthNumber)->toBe('AUTH-123')
         ->and($authorization->noReferralRequired)->toBeFalse()
         ->and($authorization->specifiesVisits)->toBeTrue()

--- a/tests/Unit/Resources/ReferralAuthorizationsTest.php
+++ b/tests/Unit/Resources/ReferralAuthorizationsTest.php
@@ -19,7 +19,8 @@ it('lists patient referral authorizations through the patient resource', functio
                     'insuranceid' => '12345',
                     'appointmentids' => [9001, 9002],
                     'startdate' => '2026-03-01',
-                    'expirationdate' => '2026-03-31',
+                    'enddate' => '2026-03-31',
+                    'expired' => false,
                     'referralauthnumber' => 'AUTH-123',
                     'noreferralrequired' => false,
                     'specifiesvisits' => true,
@@ -44,6 +45,7 @@ it('lists patient referral authorizations through the patient resource', functio
         ->and($authorizations)->toHaveCount(1)
         ->and($authorizations[0])->toBeInstanceOf(ReferralAuthorizationData::class)
         ->and($authorizations[0]->athenaId)->toBe(501)
+        ->and($authorizations[0]->isExpired)->toBeFalse()
         ->and($response->getPendingRequest()->query()->all())->toBe([
             'insuranceid' => 12345,
             'showexpired' => true,


### PR DESCRIPTION
- Introduced a new boolean property `isExpired` to the `ReferralAuthorizationData` class to indicate the expiration status.
- Updated the mapping logic in the constructor to use `enddate` instead of `expirationdate` and to set the `isExpired` property based on the input data.
- Modified unit tests to validate the new `isExpired` property and ensure correct mapping of the updated fields.