### PR TITLE
Enhance AthenaConnector token management with caching and locking

### DIFF
--- a/src/AthenaConnector.php
+++ b/src/AthenaConnector.php
@@ -55,12 +55,21 @@ class AthenaConnector extends Connector implements HasPagination
         // Attempt to set up authentication
         try {
             $authenticator = Cache::get('athena_access_token');
-            if (! $authenticator) {
-                $authenticator = $this->getAccessToken();
-                $expiresAt = $authenticator->getExpiresAt();
-                $expiresAt = $expiresAt->sub(new DateInterval('PT1M'));
-                $ttl = now()->diff($expiresAt);
-                Cache::put('athena_access_token', $authenticator, $ttl);
+            if (! $authenticator || $authenticator->hasExpired()) {
+                $authenticator = Cache::lock('athena_access_token_lock', 30)->block(10, function () {
+                    $authenticator = Cache::get('athena_access_token');
+                    if ($authenticator && $authenticator->hasNotExpired()) {
+                        return $authenticator;
+                    }
+
+                    $authenticator = $this->getAccessToken();
+                    $expiresAt = $authenticator->getExpiresAt();
+                    $expiresAt = $expiresAt->sub(new DateInterval('PT1M'));
+                    $ttl = now()->diff($expiresAt);
+                    Cache::put('athena_access_token', $authenticator, $ttl);
+
+                    return $authenticator;
+                });
             }
             $this->authenticate($authenticator);
         } catch (ReflectionException|OAuthConfigValidationException|Throwable $e) {

--- a/tests/Unit/AthenaConnectorTest.php
+++ b/tests/Unit/AthenaConnectorTest.php
@@ -7,7 +7,11 @@ use ChrisReedIO\AthenaSDK\Resources\Encounters;
 use ChrisReedIO\AthenaSDK\Resources\Patients;
 use ChrisReedIO\AthenaSDK\Resources\Practice;
 use ChrisReedIO\AthenaSDK\Resources\Providers;
+use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Support\Facades\Cache;
+use Saloon\Contracts\OAuthAuthenticator;
+use Saloon\Http\Auth\AccessTokenAuthenticator;
+use Saloon\Http\Response;
 
 beforeEach(function () {
     Cache::forget('athena_access_token');
@@ -62,6 +66,92 @@ it('creates top level resource accessors without contacting the network', functi
         ->and($connector->referringProviders())->toBeInstanceOf(Providers\ReferringProviders::class)
         ->and($connector->practice())->toBeInstanceOf(Practice::class)
         ->and($connector->encounters())->toBeInstanceOf(Encounters::class);
+});
+
+it('fetches and caches an access token when the cache is empty', function () {
+    athenaTestConfig();
+
+    $authenticator = new AccessTokenAuthenticator('fresh-access-token', null, new DateTimeImmutable('+1 hour'));
+
+    $connector = new class($authenticator) extends AthenaConnector
+    {
+        public int $accessTokenCalls = 0;
+
+        public function __construct(private readonly OAuthAuthenticator $testAuthenticator)
+        {
+            parent::__construct();
+        }
+
+        public function getAccessToken(array $scopes = [], string $scopeSeparator = ' ', bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response
+        {
+            $this->accessTokenCalls++;
+
+            return $this->testAuthenticator;
+        }
+    };
+
+    expect($connector->accessTokenCalls)->toBe(1)
+        ->and(Cache::get('athena_access_token')->getAccessToken())->toBe('fresh-access-token');
+});
+
+it('rechecks the token cache inside the lock before fetching a new token', function () {
+    athenaTestConfig();
+
+    $cachedAuthenticator = new AccessTokenAuthenticator('locked-worker-token', null, new DateTimeImmutable('+1 hour'));
+
+    Cache::shouldReceive('get')
+        ->with('athena_access_token')
+        ->twice()
+        ->andReturn(null, $cachedAuthenticator);
+
+    Cache::shouldReceive('lock')
+        ->with('athena_access_token_lock', 30)
+        ->once()
+        ->andReturn(new class implements Lock
+        {
+            public function get($callback = null)
+            {
+                return $callback ? $callback() : true;
+            }
+
+            public function block($seconds, $callback = null)
+            {
+                expect($seconds)->toBe(10);
+
+                return $callback ? $callback() : true;
+            }
+
+            public function release(): bool
+            {
+                return true;
+            }
+
+            public function owner(): string
+            {
+                return 'test-owner';
+            }
+
+            public function forceRelease(): void
+            {
+                //
+            }
+        });
+
+    Cache::shouldReceive('put')->never();
+
+    $connector = new class extends AthenaConnector
+    {
+        public int $accessTokenCalls = 0;
+
+        public function getAccessToken(array $scopes = [], string $scopeSeparator = ' ', bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response
+        {
+            $this->accessTokenCalls++;
+
+            throw new Exception('getAccessToken should not be called when a token exists inside the lock');
+        }
+    };
+
+    expect($connector->accessTokenCalls)->toBe(0);
 });
 
 it('uses a 15 requests-per-second limiter outside production', function () {


### PR DESCRIPTION
- Updated the authentication logic in `AthenaConnector` to check for token expiration and utilize a cache lock to prevent multiple simultaneous token fetches.
- Added unit tests to verify the correct behavior of token fetching and caching, ensuring that tokens are only retrieved when necessary and that existing tokens are reused appropriately.