### PR TITLE
Add InsuranceCopayData class and integrate into InsuranceData

### DIFF
--- a/src/Data/Patient/InsuranceCopayData.php
+++ b/src/Data/Patient/InsuranceCopayData.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ChrisReedIO\AthenaSDK\Data\Patient;
+
+use ChrisReedIO\AthenaSDK\Data\AthenaData;
+
+readonly class InsuranceCopayData extends AthenaData
+{
+    public function __construct(
+        public ?string $type = null,
+        public ?string $amount = null,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            type: $data['copaytype'] ?? null,
+            amount: $data['copayamount'] ?? null,
+        );
+    }
+}

--- a/src/Data/Patient/InsuranceData.php
+++ b/src/Data/Patient/InsuranceData.php
@@ -61,6 +61,8 @@ readonly class InsuranceData extends AthenaData
         public ?string $insuredSex = null,
         public ?string $insuredState = null,
         public ?string $insuredZip = null,
+        /** @var InsuranceCopayData[]|null */
+        public ?array $copays = null,
     ) {}
 
     public static function fromArray(array $data): static
@@ -120,6 +122,7 @@ readonly class InsuranceData extends AthenaData
             insuredSex: $data['insuredsex'] ?? null,
             insuredState: $data['insuredstate'] ?? null,
             insuredZip: $data['insuredzip'] ?? null,
+            copays: isset($data['copays']) ? array_map(static fn (array $copay): InsuranceCopayData => InsuranceCopayData::fromArray($copay), $data['copays']) : null,
         );
     }
 }


### PR DESCRIPTION
- Introduced a new `InsuranceCopayData` class to represent copay information.
- Updated the `InsuranceData` class to include a `copays` property, allowing for an array of `InsuranceCopayData` instances.
- Enhanced the `fromArray` method in `InsuranceData` to map copay data from the input array to the new class.