### PR TITLE
Expand get patient request

### DIFF
--- a/src/Data/Patient/InsuredSignatureData.php
+++ b/src/Data/Patient/InsuredSignatureData.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ChrisReedIO\AthenaSDK\Data\Patient;
+
+use ChrisReedIO\AthenaSDK\Data\AthenaData;
+
+readonly class InsuredSignatureData extends AthenaData
+{
+    public function __construct(
+        public ?string $effectiveDate = null,
+        public ?string $expirationDate = null,
+        public ?bool $isOnFile = null,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            effectiveDate: $data['insuredsignatureeffectivedate'] ?? null,
+            expirationDate: $data['insuredsignatureexpirationdate'] ?? null,
+            isOnFile: self::toBool($data['isinsuredsignatureonfile'] ?? null),
+        );
+    }
+}

--- a/src/Data/Patient/PatientData.php
+++ b/src/Data/Patient/PatientData.php
@@ -52,6 +52,8 @@ readonly class PatientData extends AthenaData
         public ?string $primaryProviderId = null,
 
         public ?bool $privacyInformationVerified = null,
+        public ?PatientPrivacyInfoData $detailedPrivacyInfo = null,
+        public ?PortalStatusData $portalStatus = null,
         // @var PatientBalanceData[]|null
         public ?array $balances = null,
 
@@ -91,6 +93,12 @@ readonly class PatientData extends AthenaData
             primaryDepartmentId: $data['primarydepartmentid'] ?? null,
             primaryProviderId: $data['primaryproviderid'] ?? null,
             privacyInformationVerified: self::toBool($data['privacyinformationverified'] ?? null),
+            detailedPrivacyInfo: isset($data['detailedprivacyinfo']) && is_array($data['detailedprivacyinfo'])
+                ? PatientPrivacyInfoData::fromArray($data['detailedprivacyinfo'])
+                : null,
+            portalStatus: isset($data['portalstatus']) && is_array($data['portalstatus'])
+                ? PortalStatusData::fromArray($data['portalstatus'])
+                : null,
             balances: isset($data['balances']) && is_array($data['balances'])
                 ? array_map(
                     static fn (array $balance): PatientBalanceData => PatientBalanceData::fromArray($balance),

--- a/src/Data/Patient/PatientPrivacyInfoData.php
+++ b/src/Data/Patient/PatientPrivacyInfoData.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ChrisReedIO\AthenaSDK\Data\Patient;
+
+use ChrisReedIO\AthenaSDK\Data\AthenaData;
+
+readonly class PatientPrivacyInfoData extends AthenaData
+{
+    public function __construct(
+        public ?PatientSignatureData $patientSignature = null,
+        public ?int $checkboxesConfigured = null,
+        public ?InsuredSignatureData $insuredSignature = null,
+        public ?PrivacyNoticeData $privacyNotice = null,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            patientSignature: isset($data['patientsignature']) && is_array($data['patientsignature'])
+                ? PatientSignatureData::fromArray($data['patientsignature'])
+                : null,
+            checkboxesConfigured: isset($data['checkboxesconfigured']) ? (int) $data['checkboxesconfigured'] : null,
+            insuredSignature: isset($data['insuredsignature']) && is_array($data['insuredsignature'])
+                ? InsuredSignatureData::fromArray($data['insuredsignature'])
+                : null,
+            privacyNotice: isset($data['privacynotice']) && is_array($data['privacynotice'])
+                ? PrivacyNoticeData::fromArray($data['privacynotice'])
+                : null,
+        );
+    }
+}

--- a/src/Data/Patient/PatientSignatureData.php
+++ b/src/Data/Patient/PatientSignatureData.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ChrisReedIO\AthenaSDK\Data\Patient;
+
+use ChrisReedIO\AthenaSDK\Data\AthenaData;
+
+readonly class PatientSignatureData extends AthenaData
+{
+    public function __construct(
+        public ?string $effectiveDate = null,
+        public ?string $expirationDate = null,
+        public ?bool $isOnFile = null,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            effectiveDate: $data['patientsignatureeffectivedate'] ?? null,
+            expirationDate: $data['patientsignatureexpirationdate'] ?? null,
+            isOnFile: self::toBool($data['ispatientsignatureonfile'] ?? null),
+        );
+    }
+}

--- a/src/Data/Patient/PortalStatusData.php
+++ b/src/Data/Patient/PortalStatusData.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ChrisReedIO\AthenaSDK\Data\Patient;
+
+use ChrisReedIO\AthenaSDK\Data\AthenaData;
+
+readonly class PortalStatusData extends AthenaData
+{
+    public function __construct(
+        public ?bool $familyBlockedFailedLogins = null,
+        public ?string $status = null,
+        public ?bool $familyRegistered = null,
+        public ?string $lastLoginDate = null,
+        public ?string $entityToDisplay = null,
+        public ?bool $registered = null,
+        public ?string $lastLoginEntity = null,
+        public ?bool $blockedFailedLogins = null,
+        public ?bool $termsAccepted = null,
+        public ?bool $noPortal = null,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            familyBlockedFailedLogins: self::toBool($data['familyblockedfailedlogins'] ?? null),
+            status: $data['status'] ?? null,
+            familyRegistered: self::toBool($data['familyregistered'] ?? null),
+            lastLoginDate: $data['lastlogindate'] ?? null,
+            entityToDisplay: $data['entitytodisplay'] ?? null,
+            registered: self::toBool($data['registered'] ?? null),
+            lastLoginEntity: $data['lastloginentity'] ?? null,
+            blockedFailedLogins: self::toBool($data['blockedfailedlogins'] ?? null),
+            termsAccepted: self::toBool($data['termsaccepted'] ?? null),
+            noPortal: self::toBool($data['noportal'] ?? null),
+        );
+    }
+}

--- a/src/Data/Patient/PrivacyNoticeData.php
+++ b/src/Data/Patient/PrivacyNoticeData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ChrisReedIO\AthenaSDK\Data\Patient;
+
+use ChrisReedIO\AthenaSDK\Data\AthenaData;
+
+readonly class PrivacyNoticeData extends AthenaData
+{
+    public function __construct(
+        public ?string $givenDate = null,
+        public ?bool $isOnFile = null,
+        public ?string $notGivenNote = null,
+        public ?string $notGivenReason = null,
+    ) {}
+
+    public static function fromArray(array $data): static
+    {
+        return new static(
+            givenDate: $data['privacynoticegivendate'] ?? null,
+            isOnFile: self::toBool($data['isprivacynoticeonfile'] ?? null),
+            notGivenNote: $data['privacynoticenotgivennote'] ?? null,
+            notGivenReason: $data['privacynoticenotgivenreason'] ?? null,
+        );
+    }
+}

--- a/src/Requests/Patient/GetPatient.php
+++ b/src/Requests/Patient/GetPatient.php
@@ -45,6 +45,7 @@ class GetPatient extends Request
      * @param  null|bool  $showportalstatus  If set, will include portal enrollment status in response.
      * @param  null|bool  $showpreviouspatientids  If set, will show the previous patient ID this patient was merged from.
      * @param  null|bool  $showprivacycustomfields  Include privacy custom fields for the patient when SHOWCUSTOMFIELDS also set to true.
+     * @param  null|bool  $showprivacyinfo  Include privacy information for the patient.
      */
     public function __construct(
         protected int $patientid,
@@ -58,7 +59,7 @@ class GetPatient extends Request
         protected ?bool $show2015edcehrtvalues = null,
         protected ?bool $showallclaims = null,
         protected ?bool $showallpatientdepartmentstatus = null,
-        protected ?bool $showbalancedetails = null,
+        protected ?bool $showbalancedetails = true,
         protected ?bool $showcustomfields = true,
         protected ?bool $showfullssn = null,
         protected ?bool $showinsurance = true,
@@ -66,6 +67,7 @@ class GetPatient extends Request
         protected ?bool $showportalstatus = true,
         protected ?bool $showpreviouspatientids = null,
         protected ?bool $showprivacycustomfields = null,
+        protected ?bool $showprivacyinfo = true,
     ) {}
 
     public function defaultQuery(): array
@@ -89,6 +91,7 @@ class GetPatient extends Request
             'showportalstatus' => $this->showportalstatus,
             'showpreviouspatientids' => $this->showpreviouspatientids,
             'showprivacycustomfields' => $this->showprivacycustomfields,
+            'showprivacyinfo' => $this->showprivacyinfo,
         ]);
     }
 

--- a/tests/Unit/Data/PatientPrivacyInfoDataTest.php
+++ b/tests/Unit/Data/PatientPrivacyInfoDataTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use ChrisReedIO\AthenaSDK\Data\Patient\PatientData;
+use ChrisReedIO\AthenaSDK\Data\Patient\PatientPrivacyInfoData;
+
+it('maps detailed privacy info from the patient payload', function () {
+    $privacyInfo = PatientPrivacyInfoData::fromArray([
+        'patientsignature' => [
+            'patientsignatureeffectivedate' => '05/08/2025',
+            'patientsignatureexpirationdate' => '05/08/2026',
+            'ispatientsignatureonfile' => false,
+        ],
+        'checkboxesconfigured' => 1,
+        'insuredsignature' => [
+            'insuredsignatureeffectivedate' => '05/08/2025',
+            'insuredsignatureexpirationdate' => '05/08/2026',
+            'isinsuredsignatureonfile' => false,
+        ],
+        'privacynotice' => [
+            'privacynoticegivendate' => '05/08/2025',
+            'isprivacynoticeonfile' => true,
+            'privacynoticenotgivennote' => 'Patient declined',
+            'privacynoticenotgivenreason' => 'OTHER',
+        ],
+    ]);
+
+    expect($privacyInfo->checkboxesConfigured)->toBe(1)
+        ->and($privacyInfo->patientSignature?->effectiveDate)->toBe('05/08/2025')
+        ->and($privacyInfo->patientSignature?->expirationDate)->toBe('05/08/2026')
+        ->and($privacyInfo->patientSignature?->isOnFile)->toBeFalse()
+        ->and($privacyInfo->insuredSignature?->effectiveDate)->toBe('05/08/2025')
+        ->and($privacyInfo->insuredSignature?->expirationDate)->toBe('05/08/2026')
+        ->and($privacyInfo->insuredSignature?->isOnFile)->toBeFalse()
+        ->and($privacyInfo->privacyNotice?->givenDate)->toBe('05/08/2025')
+        ->and($privacyInfo->privacyNotice?->isOnFile)->toBeTrue()
+        ->and($privacyInfo->privacyNotice?->notGivenNote)->toBe('Patient declined')
+        ->and($privacyInfo->privacyNotice?->notGivenReason)->toBe('OTHER');
+});
+
+it('maps detailed privacy info on patient data', function () {
+    $patient = PatientData::fromArray([
+        'patientid' => 123,
+        'detailedprivacyinfo' => [
+            'patientsignature' => [
+                'patientsignatureeffectivedate' => '05/08/2025',
+                'patientsignatureexpirationdate' => '05/08/2026',
+                'ispatientsignatureonfile' => true,
+            ],
+            'checkboxesconfigured' => 1,
+            'insuredsignature' => [
+                'insuredsignatureeffectivedate' => '05/08/2025',
+                'insuredsignatureexpirationdate' => '05/08/2026',
+                'isinsuredsignatureonfile' => true,
+            ],
+            'privacynotice' => [
+                'privacynoticegivendate' => '05/08/2025',
+                'isprivacynoticeonfile' => true,
+            ],
+        ],
+    ]);
+
+    expect($patient->detailedPrivacyInfo?->checkboxesConfigured)->toBe(1)
+        ->and($patient->detailedPrivacyInfo?->patientSignature?->isOnFile)->toBeTrue();
+});

--- a/tests/Unit/Data/PortalStatusDataTest.php
+++ b/tests/Unit/Data/PortalStatusDataTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use ChrisReedIO\AthenaSDK\Data\Patient\PatientData;
+use ChrisReedIO\AthenaSDK\Data\Patient\PortalStatusData;
+
+it('maps portal status from the patient payload', function () {
+    $portalStatus = PortalStatusData::fromArray([
+        'familyblockedfailedlogins' => false,
+        'status' => 'REGISTERED',
+        'familyregistered' => false,
+        'lastlogindate' => '06/30/2025',
+        'entitytodisplay' => 'PATIENT',
+        'registered' => true,
+        'lastloginentity' => 'PATIENT',
+        'blockedfailedlogins' => false,
+        'termsaccepted' => true,
+        'noportal' => false,
+    ]);
+
+    expect($portalStatus->familyBlockedFailedLogins)->toBeFalse()
+        ->and($portalStatus->status)->toBe('REGISTERED')
+        ->and($portalStatus->familyRegistered)->toBeFalse()
+        ->and($portalStatus->lastLoginDate)->toBe('06/30/2025')
+        ->and($portalStatus->entityToDisplay)->toBe('PATIENT')
+        ->and($portalStatus->registered)->toBeTrue()
+        ->and($portalStatus->lastLoginEntity)->toBe('PATIENT')
+        ->and($portalStatus->blockedFailedLogins)->toBeFalse()
+        ->and($portalStatus->termsAccepted)->toBeTrue()
+        ->and($portalStatus->noPortal)->toBeFalse();
+});
+
+it('maps portal status on patient data', function () {
+    $patient = PatientData::fromArray([
+        'patientid' => 123,
+        'portalstatus' => [
+            'status' => 'REGISTERED',
+            'registered' => true,
+        ],
+    ]);
+
+    expect($patient->portalStatus?->status)->toBe('REGISTERED')
+        ->and($patient->portalStatus?->registered)->toBeTrue();
+});

--- a/tests/Unit/Data/ReferralAuthorizationDataTest.php
+++ b/tests/Unit/Data/ReferralAuthorizationDataTest.php
@@ -6,7 +6,7 @@ it('maps representative referral authorization payload fields into a dto', funct
     $authorization = ReferralAuthorizationData::fromArray([
         'referralauthid' => '501',
         'departmentid' => '77',
-        'insuranceid' => '12345',
+        'insuranceidnumber' => '12345',
         'appointmentids' => ['9001', '9002'],
         'startdate' => '2026-03-01',
         'enddate' => '2026-03-31',


### PR DESCRIPTION
This pull request adds support for detailed patient privacy information and portal status to the data model, improves the mapping of these fields from API responses, and ensures they are included in the patient request and response flow. It introduces several new data classes, updates the patient data structure, modifies the patient API request to include new parameters by default, and adds comprehensive unit tests.

**Patient Data Model Enhancements:**

* Added new data classes: `PatientPrivacyInfoData`, `PatientSignatureData`, `InsuredSignatureData`, `PrivacyNoticeData`, and `PortalStatusData` to encapsulate privacy and portal status details. [[1]](diffhunk://#diff-51138561cc29da3d33abe6395522ca527ee3cd21cf57d7ac77e39fa685270d94R1-R31) [[2]](diffhunk://#diff-1b38b4828fe1635863b9da8d0ecd53a37b8f0183cd9ded3488ec8faa5d13b41dR1-R23) [[3]](diffhunk://#diff-bc31c8c01fb53cdd20f04e157b6cdb19c14c73caba8f4828954a8c6e8eb61d70R1-R23) [[4]](diffhunk://#diff-396c14bd4dc7aa3f903e5b105798a99913e0a461df5310ad4d718f9ac8962064R1-R25) [[5]](diffhunk://#diff-cc0050e36acd9ca0231fb6cd81688483452a6e369384916f624e2db85fdf3ee3R1-R37)
* Updated `PatientData` to include `detailedPrivacyInfo` and `portalStatus` properties, with logic to map these from the payload. [[1]](diffhunk://#diff-dd26f697c8fef703c14ea99a64b54ea5d817b04cc4660c0c885436de98fee5c0R55-R56) [[2]](diffhunk://#diff-dd26f697c8fef703c14ea99a64b54ea5d817b04cc4660c0c885436de98fee5c0R96-R101)

**API Request Changes:**

* Updated `GetPatient` request to support the `showprivacyinfo` parameter, and set `showprivacyinfo`, `showportalstatus`, and `showbalancedetails` to `true` by default. [[1]](diffhunk://#diff-54d48a72a544066867f6505c1044416bcf72f7ab07e700c59fd6696bd1d7f9a3R48) [[2]](diffhunk://#diff-54d48a72a544066867f6505c1044416bcf72f7ab07e700c59fd6696bd1d7f9a3L61-R70) [[3]](diffhunk://#diff-54d48a72a544066867f6505c1044416bcf72f7ab07e700c59fd6696bd1d7f9a3R94)

**Testing Improvements:**

* Added unit tests to verify correct mapping of privacy info and portal status from payloads and within `PatientData`. [[1]](diffhunk://#diff-8a4d5ef76f74051534a1d2dd6816ec48bb946b78c631e8a7c26cb96aba5828cfR1-R64) [[2]](diffhunk://#diff-398f9feec956fabd4227279c29d62b8321099e374698c73f29448b4939f78e35R1-R43)