### PR TITLE
feat(department): add providerGroupId to DepartmentData and update Patient retrieval

### DIFF
--- a/src/Data/Department/DepartmentData.php
+++ b/src/Data/Department/DepartmentData.php
@@ -13,6 +13,7 @@ readonly class DepartmentData extends AthenaData
         public ?string $patientName = null,
         public ?string $phone = null,
         public ?int $timezone = null,
+        public ?string $providerGroupId = null,
         public ?AddressData $address = null,
     ) {}
 
@@ -24,8 +25,8 @@ readonly class DepartmentData extends AthenaData
             patientName: $data['patientdepartmentname'] ?? null,
             phone: $data['phone'] ?? null,
             timezone: $data['timezone'] ?? null,
+            providerGroupId: $data['providergroupid'] ?? null,
             address: (isset($data['address']) ? AddressData::fromArray($data) : null),
-
         );
     }
 }

--- a/src/Data/Patient/PatientData.php
+++ b/src/Data/Patient/PatientData.php
@@ -13,7 +13,7 @@ readonly class PatientData extends AthenaData
      */
     public function __construct(
         public ?int $athenaId = null,
-        public ?int $athenaLocalId = null,
+        public ?string $athenaLocalId = null,
         public ?string $firstName = null,
         public ?string $lastName = null,
         public ?string $sex = null,
@@ -63,7 +63,7 @@ readonly class PatientData extends AthenaData
     {
         return new static(
             athenaId: $data['patientid'] ?? null,
-            athenaLocalId: isset($data['localpatientid']) ? (int) $data['localpatientid'] : null,
+            athenaLocalId: isset($data['localpatientid']) ? $data['localpatientid'] : null,
             firstName: $data['firstname'] ?? null,
             lastName: $data['lastname'] ?? null,
             sex: $data['sex'] ?? null,

--- a/src/Data/Patient/PatientData.php
+++ b/src/Data/Patient/PatientData.php
@@ -13,6 +13,7 @@ readonly class PatientData extends AthenaData
      */
     public function __construct(
         public ?int $athenaId = null,
+        public ?int $athenaLocalId = null,
         public ?string $firstName = null,
         public ?string $lastName = null,
         public ?string $sex = null,
@@ -62,6 +63,7 @@ readonly class PatientData extends AthenaData
     {
         return new static(
             athenaId: $data['patientid'] ?? null,
+            athenaLocalId: isset($data['localpatientid']) ? (int) $data['localpatientid'] : null,
             firstName: $data['firstname'] ?? null,
             lastName: $data['lastname'] ?? null,
             sex: $data['sex'] ?? null,

--- a/src/Requests/Patient/GetPatient.php
+++ b/src/Requests/Patient/GetPatient.php
@@ -85,7 +85,7 @@ class GetPatient extends Request
             'showcustomfields' => $this->showcustomfields,
             'showfullssn' => $this->showfullssn,
             'showinsurance' => $this->showinsurance,
-            'showlocalpatientid' => true,
+            'showlocalpatientid' => $this->showlocalpatientid,
             'showportalstatus' => $this->showportalstatus,
             'showpreviouspatientids' => $this->showpreviouspatientids,
             'showprivacycustomfields' => $this->showprivacycustomfields,

--- a/src/Requests/Patient/GetPatient.php
+++ b/src/Requests/Patient/GetPatient.php
@@ -85,7 +85,7 @@ class GetPatient extends Request
             'showcustomfields' => $this->showcustomfields,
             'showfullssn' => $this->showfullssn,
             'showinsurance' => $this->showinsurance,
-            'showlocalpatientid' => $this->showlocalpatientid,
+            'showlocalpatientid' => true,
             'showportalstatus' => $this->showportalstatus,
             'showpreviouspatientids' => $this->showpreviouspatientids,
             'showprivacycustomfields' => $this->showprivacycustomfields,

--- a/src/Resources/Patients.php
+++ b/src/Resources/Patients.php
@@ -32,8 +32,7 @@ class Patients extends Resource
         int $patientId,
         ?bool $limitLocalPatientId = null,
         ?string $departmentId = null,
-    ): PatientData
-    {
+    ): PatientData {
         return $this->connector->send(new GetPatient(
             patientid: $patientId,
             limitlocalpatientid: $limitLocalPatientId,

--- a/src/Resources/Patients.php
+++ b/src/Resources/Patients.php
@@ -30,11 +30,13 @@ class Patients extends Resource
 
     public function get(
         int $patientId,
+        ?bool $showLocalPatientId = null,
         ?bool $limitLocalPatientId = null,
         ?string $departmentId = null,
     ): PatientData {
         return $this->connector->send(new GetPatient(
             patientid: $patientId,
+            showlocalpatientid: $showLocalPatientId,
             limitlocalpatientid: $limitLocalPatientId,
             departmentid: $departmentId,
         ))->dtoOrFail();

--- a/src/Resources/Patients.php
+++ b/src/Resources/Patients.php
@@ -28,9 +28,17 @@ class Patients extends Resource
     //     return $this->connector->send(new ListPatients(departmentid: $departmentId));
     // }
 
-    public function get(int $patientId): PatientData
+    public function get(
+        int $patientId,
+        ?bool $limitLocalPatientId = null,
+        ?string $departmentId = null,
+    ): PatientData
     {
-        return $this->connector->send(new GetPatient($patientId))->dtoOrFail();
+        return $this->connector->send(new GetPatient(
+            patientid: $patientId,
+            limitlocalpatientid: $limitLocalPatientId,
+            departmentid: $departmentId,
+        ))->dtoOrFail();
     }
 
     public function subscriptions(): PatientSubscriptions


### PR DESCRIPTION
- Introduced a new property `providerGroupId` in `DepartmentData` to capture provider group information.
- Updated the `GetPatient` request to always show the local patient ID.
- Enhanced the `get` method in `Patients` resource to accept optional parameters for `limitLocalPatientId` and `departmentId`.