### PR TITLE
Stop requesting appointment patient detail by default

### DIFF
--- a/src/Resources/Appointments/AppointmentSubscriptions.php
+++ b/src/Resources/Appointments/AppointmentSubscriptions.php
@@ -39,8 +39,7 @@ class AppointmentSubscriptions extends Resource
         ?bool $showCopay = true,
         ?bool $showInsurance = true,
         ?bool $showPatientDetail = null,
-    ): LazyCollection
-    {
+    ): LazyCollection {
         $request = new ListAppointmentChanges(
             leaveUnprocessed: $leaveUnprocessed,
             showCopay: $showCopay,

--- a/src/Resources/Appointments/AppointmentSubscriptions.php
+++ b/src/Resources/Appointments/AppointmentSubscriptions.php
@@ -34,13 +34,18 @@ class AppointmentSubscriptions extends Resource
         return $this->connector->send(new DeleteAppointmentChangeSubscription($eventName));
     }
 
-    public function changes(bool $leaveUnprocessed = false): LazyCollection
+    public function changes(
+        ?bool $leaveUnprocessed = false,
+        ?bool $showCopay = true,
+        ?bool $showInsurance = true,
+        ?bool $showPatientDetail = null,
+    ): LazyCollection
     {
         $request = new ListAppointmentChanges(
             leaveUnprocessed: $leaveUnprocessed,
-            showCopay: true,
-            showInsurance: true,
-            showPatientDetail: true,
+            showCopay: $showCopay,
+            showInsurance: $showInsurance,
+            showPatientDetail: $showPatientDetail,
         );
 
         return $this->connector

--- a/src/Resources/Appointments/AppointmentSubscriptions.php
+++ b/src/Resources/Appointments/AppointmentSubscriptions.php
@@ -38,7 +38,7 @@ class AppointmentSubscriptions extends Resource
         ?bool $leaveUnprocessed = false,
         ?bool $showCopay = true,
         ?bool $showInsurance = true,
-        ?bool $showPatientDetail = null,
+        ?bool $showPatientDetail = true,
     ): LazyCollection {
         $request = new ListAppointmentChanges(
             leaveUnprocessed: $leaveUnprocessed,


### PR DESCRIPTION
Passport no longer uses patient detail from the appointment change response.

That response only returns the enterprise MRN account for the patient, which is not always the correct patient context for a specific appointment. We now fetch patient data separately and scope that request to the appointment's department so we reliably get the correct patient.

Because of that, including patient detail in every appointment change request is unnecessary and only adds extra response payload and processing. It also has the rare chance that Athena gives us a 500 error when it cannot find/attach the patient details to the appointment...